### PR TITLE
Legger til environment i deploy jobb for å vise deployhistorikk på github repo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: ${{inputs.cluster}}
     steps:
       - uses: actions/checkout@v4
       - uses: nais/login@v0


### PR DESCRIPTION
Forhåpentligvis vil endringen gi reposiden et deploykort som viser deployhistorikken.
![image](https://github.com/user-attachments/assets/2dddb202-febd-44ab-bb50-bb8146725843)

Det skan også gjøre det mulig å sette miljøspesifikke deploy regler.